### PR TITLE
enable mock bank and fix store types

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ If you wish to use this driver with your own TrueLayer account then:
 - Copy and paste `client_id` and `client_secret` into the driver and click Authorize.
 - In the driver settings, choose the bank account you wish to monitor and the Refresh Interval (in minutes).
 
+Note: (if enabled in the driver) you can use a mock bank and mock account(s)
+for testing - follow the authentication flow and select 'mock bank'. 
+The login screen suggests a default mock user to try.
 
 # Data stored
 This driver writes transactional event data into a store-json for later processing.
@@ -24,6 +27,36 @@ It saves the following streams of data:
 
 These can then be accessed store-json API.
 
+See truelayer types for 
+[transactions](https://docs.truelayer.com/#retrieve-account-transactions)
+and
+[balances](https://docs.truelayer.com/#retrieve-account-balance)
+
+## Issues
+
+- add value examples
+
+- redirect URLs are hard-coded as https://127.0.0.1/... 
+so will only work from a local browser (not the app)
+
+- only the success flow is handled, e.g. user cancelling
+authentication isn't handled (raises exception, view times out).
+
+- the client secret is accessible - should be at least hidden
+as a password field.
+
+- there is no status visible to the user, e.g. that it has 
+been configured (or not), and with which account (if any) 
+after the initial authentication flow has completed.
+
+- the authentication flow ends with a redirect to an app page
+in a separate browser tab, i.e. not within the core-ui.
+
+- there is no way to stop the driver once successfully configured
+(other than uninstalling it and authenticating successfully again
+with a different account). This is partly because the authentication
+failures are not handled, so old authentication information is
+retained and used, but an explicit option would be good.
 
 ## Databox is funded by the following grants:
 

--- a/src/main.js
+++ b/src/main.js
@@ -181,7 +181,7 @@ balance.ContentType = 'application/json';
 balance.Vendor = 'Databox Inc.';
 balance.DataSourceType = 'truelayerUserBalance';
 balance.DataSourceID = 'truelayerUserBalance';
-balance.StoreType = 'ts';
+balance.StoreType = 'ts/blob';
 
 const transactions = databox.NewDataSourceMetadata();
 transactions.Description = 'TrueLayer user Transactions data';
@@ -189,7 +189,7 @@ transactions.ContentType = 'application/json';
 transactions.Vendor = 'Databox Inc.';
 transactions.DataSourceType = 'truelayerUserTransactions';
 transactions.DataSourceID = 'truelayerUserTransactions';
-transactions.StoreType = 'ts';
+transactions.StoreType = 'ts/blob';
 
 const driverSettings = databox.NewDataSourceMetadata();
 driverSettings.Description = 'TrueLayer driver settings';

--- a/src/main.js
+++ b/src/main.js
@@ -80,6 +80,7 @@ app.get('/ui/authenticate', function (req, res) {
         redirectURI: redirect_url,
         scope: permission_scopes,
         nonce: nonce(8),
+        enableMock: true, // enable mock/testing provider(s)
       });
 
       // Used 'target=_blank' since TrueLayer doesn't support inner html.


### PR DESCRIPTION
Enable the mock bank - useful for testing - and correct the balance and transaction data source store types to 'ts/blob' (as used - required for correct access permissions from apps).